### PR TITLE
Rollback node to lts version

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine
+FROM node:lts-alpine
 
 WORKDIR /api
 

--- a/api/dockerfile.dev
+++ b/api/dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:alpine
+FROM node:lts-alpine
 
 WORKDIR /api
 


### PR DESCRIPTION
To leverage the standard instance of Google App Engine
we needed to rollback node to the LTS version
so that the app instances can scale down to 0