### PR TITLE
From usability enhancements

### DIFF
--- a/ui/src/childinfo/ChildInfo.js
+++ b/ui/src/childinfo/ChildInfo.js
@@ -46,7 +46,10 @@ export default class ChildInfo extends Component {
     }
   }
 
-  nextStep = async () => {
+  nextStep = async (e) => {
+    if (typeof e !== 'undefined') {
+      e.preventDefault();
+    }
     let stepMap = this.stepMapFunction();
     let { step } = this.state;
     if (step < Object.keys(stepMap).length - 1) {
@@ -130,13 +133,12 @@ export default class ChildInfo extends Component {
         <Fragment>
           {
             !showConfirmation ?
-              
               <body className="first">
               <div className='childInfo containerVertical spotlight inner'>
                 <p className='progress'>{step + 1} of {this.numSteps}</p>
                 <p className="text-name">{this.getTextField()}</p>
                 {step ? //first step should not have any input
-                  <form>
+                  <form onSubmit={this.nextStep}>
                     <input className='input-value' type="text" value={inputValue} onChange={this.updateInputField} />
                   </form>
                   : ''

--- a/ui/src/landing/splashScreen/index.js
+++ b/ui/src/landing/splashScreen/index.js
@@ -17,7 +17,7 @@ export const Landing = ({ name, age, updateField, selectWishType }) => {
         <input data-test="age-input" placeholder="your age" type="number" className="age-input" onChange={(e) => updateField(ageField, e.target.value)} value={age}/>
         <span> years old!</span>
       </div>
-      <WishTypeList selectWishType={selectWishType}/>
+      <WishTypeList hidden={name === '' || age === ''} selectWishType={selectWishType} />
     </div>
   )
 }

--- a/ui/src/landing/wishTypeList/index.js
+++ b/ui/src/landing/wishTypeList/index.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react'
+import React from 'react'
 import { WishType } from '../wishType'
 import Rocket from '../../assets/images/icn_To_Go_Rocket_White_Inside_130x130.png'
 import Alien from '../../assets/images/icn_To_Meet_Alien_White_Inside_130x130.png'
@@ -7,11 +7,11 @@ import Telescope from '../../assets/images/icn_To_See_Telescope_White_Inside_130
 import { WishTypeCard } from '../wishTypeCard'
 import './styles.scss'
 
-export const WishTypeList = ({ selectWishType }) => {
+export const WishTypeList = ({ hidden, selectWishType }) => {
   const { GO, MEET, BE, SEE } = WishType
 
   return (
-    <Fragment>
+    <div id="WishTypeContainer" className={hidden ? "hidden" : ""}>
       <h1>I wish to:</h1>
       <ul id="WishTypeList" className="wish-type-select">
         <li data-test="wishcard-rocket" onClick={() => selectWishType(GO)}>
@@ -27,6 +27,6 @@ export const WishTypeList = ({ selectWishType }) => {
           <WishTypeCard altText="Telescope" imgSrc={Telescope} title={SEE} subtitle="Something!" />
         </li>
       </ul>
-    </Fragment>
+    </div>
   )
 }

--- a/ui/src/landing/wishTypeList/styles.scss
+++ b/ui/src/landing/wishTypeList/styles.scss
@@ -1,5 +1,14 @@
 @import "../../styles/colors";
 
+#WishTypeContainer {
+    transition: opacity 500ms ease-in-out;
+    opacity: 1;
+}
+
+#WishTypeContainer.hidden {
+    opacity: 0;
+}
+
 #WishTypeList {
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
### What was the feature/problem?

There are small usability issues on the new wish (landing) page as well as the child info form.
1. **Landing Page** - the current behavior of app is to move onto the child info form so long as all three form properties are non-empty: name, age, and wish type. There is no visible feedback to show that a wish type has been selected, which resulted in unexpected behavior if you click a wish type *before* entering name/age. 

2. **Child Info Form** - Pressing the enter key would refresh the page and therefore kick you out of the form and forcing you to restart from the beginning. 

### How does this PR address the above feature/problem?

1. **Landing Page** - Hides the Wish Type selection until the user has entered both name and age.

2. **Child Info Form** - Pressing enter now moves the user to the next step. This also prevents the default behavior of a form so the page isn't reloaded. There is a nil check on the event for the sake of the tests.


### Check lists (check `x` in `[ ]` of list items)

- [X] Test passed
- [X] Coding style (indentation, etc)

### Additional Comments (if any)
- Hiding the Wish Type selection could have been done with fewer lines of code, but I added a subtle animation on the opacity so there is a nice "fade in" effect once the user has entered name and age.