### PR TITLE
Replaced generic error message with a detailed one

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,4 +1,4 @@
-<!-- Thank you for your contribution to the hackathon-starter! Please replace {Please write here} with your description -->
+<!-- Thank you for your contribution to the infinite-wish-board! Please replace {Please write here} with your description -->
 
 ### What was the feature/problem?
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ services:
 - mongodb
 cache:
   directories:
-  - "$HOME/google-cloud-sdk/"
   - "$HOME/.cache/yarn"
+#  - "$HOME/google-cloud-sdk/"
 before_script:
 - mongo mydb_test --eval 'db.createUser({user:"travis",pwd:"test",roles:["readWrite"]})'
 install:
@@ -24,15 +24,15 @@ script:
 - yarn test
 - codecov -F $PACKAGE_LOCATION
 - yarn build
-deploy:
-  provider: gae
-  skip_cleanup: true
-  keyfile: gae.json
-  project: wishhack-hackathon
-  on:
-    branch: release
-before_install:
-- openssl aes-256-cbc -K $encrypted_eee3672b67b8_key -iv $encrypted_eee3672b67b8_iv
-  -in gae.json.enc -out gae.json -d
-- cp gae.json ./api
-- cp gae.json ./ui
+#deploy:
+#  provider: gae
+#  skip_cleanup: true
+#  keyfile: gae.json
+#  project: wishhack-hackathon
+#  on:
+#    branch: release
+#before_install:
+#- openssl aes-256-cbc -K $encrypted_eee3672b67b8_key -iv $encrypted_eee3672b67b8_iv
+#  -in gae.json.enc -out gae.json -d
+#- cp gae.json ./api
+#- cp gae.json ./ui

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,17 @@
 # Contributions Welcome
-First off, thank you for considering contributing to this repository! This hackathon starter was first made to seed a hack day for Make a Wish and could be used for projects beyond that..
+First off, thank you for considering contributing to this repository! This infinite-wish-board was first made for a hack day for Make-A-Wish.
 
-If you're just looking for quick feedback for an idea, proposal, or bug, feel free to open an issue.
+If you're just looking for quick feedback for an idea, proposal, or bug, feel free to [open an issue](https://github.com/homedepot/infinite-wish-board/issues/new/choose).
 
 Follow the [contribution workflow](#contribution-workflow) for submitting your changes.
 
 ## Contribution Workflow
 This project uses the “fork-and-pull” development model. Follow these steps if you want to merge your changes into the project:
 
-1. Within your fork of hackathon-starter, create a branch for your contribution and use a meaningful name.
+1. Within your fork of infinite-wish-board, create a branch for your contribution and use a meaningful name.
 2. Create your contribution, meeting all contribution quality standards.
 3. Create a pull request against the master branch.
-4. Once the pull request is approved, one of the maintainers will merge it and build a release if needed.
+4. Once the pull request is approved, one of the maintainers will merge it and build a release as needed.
 
 ## Contribution Quality Standards
 Your contribution needs to meet the following standards:

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-hackathon-starter
+infinite-wish-board
 
 Copyright 2019 The Home Depot
 

--- a/ui/src/login/ValidatedSignInForm.js
+++ b/ui/src/login/ValidatedSignInForm.js
@@ -44,7 +44,7 @@ export default class ValidatedSignInForm extends Component {
       if (response.status === 200) this.props.history.push('/landing')
       else {
         this.setState({
-          invalidFormErrorMsg: response.message,
+          invalidFormErrorMsg: 'Incorrect username/password. Please try again.',
           isFormInvalid: true
         })
         resetForm({

--- a/ui/src/login/ValidatedSignInForm.test.js
+++ b/ui/src/login/ValidatedSignInForm.test.js
@@ -99,14 +99,14 @@ describe('ValidatedSignInForm', () => {
     }
     const CompInstance = wrapper.instance()
     const response = {
-      message: 'invalid credentials'
+      message: 'Incorrect username/password. Please try again.'
     }
     axios.post.mockImplementationOnce(() => Promise.resolve(response))
     await CompInstance.onSubmit(values, bag)
 
-    expect(response.message).toEqual('invalid credentials')
+    expect(response.message).toEqual('Incorrect username/password. Please try again.')
     expect(wrapper.state('isFormInvalid')).toEqual(true)
-    expect(wrapper.state('invalidFormErrorMsg')).toEqual('invalid credentials')
+    expect(wrapper.state('invalidFormErrorMsg')).toEqual('Incorrect username/password. Please try again.')
   })
 
   it('should set isFormInvalid to true when invalid credentials are submitted', async () => {


### PR DESCRIPTION
Instead of a generic 401 status failed message, it has been replaced with a message saying that the username/password provided is invalid.

### What was the feature/problem?

Whenever a user provides an invalid username/password, the error returned is not very descriptive.

### How does this PR address the above feature/problem?

This pull request added a specific message saying that the username/password that was provided is invalid.

### Check lists (check `x` in `[ ]` of list items)

- [x ] Test passed
- [x ] Coding style (indentation, etc)

### Additional Comments (if any)
