### PR TITLE
Wish Curation List: Search fails when there isn't an assigned sponsor

### DIFF
--- a/ui/src/wishList/index.js
+++ b/ui/src/wishList/index.js
@@ -41,7 +41,11 @@ export default class WishList extends Component {
     const wishFilter = e.target.value;
     let filteredWishes = this.state.wishes;
     filteredWishes = filteredWishes.filter((wish) => {
-      let wishItem = wish.child.name.toLowerCase() + wish.sponsor.name.toLowerCase() + wish.child.hometown.toLowerCase();
+      const child = wish.child.name ? wish.child.name.toLowerCase() : "";
+      const sponsor = wish.sponsor.name ? wish.sponsor.name.toLowerCase() : "";
+      const hometown = wish.child.hometown ? wish.child.hometown.toLowerCase() : "";
+      let wishItem = child + sponsor + hometown;
+      
       return wishItem.indexOf(
         wishFilter.toLowerCase()) !== -1
     })

--- a/ui/src/wishList/index.test.js
+++ b/ui/src/wishList/index.test.js
@@ -164,4 +164,61 @@ describe('WishSummary tests', () => {
       expect(wrapper.instance().state.filteredWishes).toEqual(mockWishList)
     })
   })
+
+  describe('when filterWishes encounters undefined values', () => {
+    let wrapper
+    beforeEach(() => {
+      mockWishList.push(
+              {
+                child: {
+                  name: 'lila',
+                  hometown: '',
+                  illness: 'non-absorbent',
+                  age: 10
+                },
+                sponsor: {
+                  links: [],
+                  name: '',
+                  logo: ''
+                },
+                _id: '5d070ba5db7b540028dea1c5',
+                type: 'go',
+                details: 'dfehjhgjhgjdf',
+                createdAt: '2019-06-17T03:40:21.782Z',
+                updatedAt: '2019-06-17T03:40:21.782Z',
+                __v: 0
+              },{
+                child: {
+                  name: 'jasmine',
+                  hometown: '',
+                  illness: 'non-absorbent',
+                  age: 10
+                },
+                sponsor: {},
+                _id: '5d070ba5db7b540028dea1c5',
+                type: 'go',
+                details: 'dfehjhgjhgjdf',
+                createdAt: '2019-06-17T03:40:21.782Z',
+                updatedAt: '2019-06-17T03:40:21.782Z',
+                __v: 0
+              }
+            );
+            getWishes.mockImplementation(() => mockWishList)
+            wrapper = shallow(<WishSummary />)
+          });
+
+    it('should update filterWishes by sponsor not', async () => {
+      let clickEvt = {
+        target: {
+          value: 'Home Depot'
+        }
+      }
+      const wishes = wrapper.find(Wish)
+      wrapper.instance().filterWishes(clickEvt)
+
+      expect(wishes.length).toEqual(5)
+      expect(wrapper.instance().state.filteredWishes.length).toEqual(3)
+      expect(wrapper.instance().state.filteredWishes.includes("lila")).toEqual(false)
+    })
+  })
 })


### PR DESCRIPTION
<!-- Thank you for your contribution to the infinite-wish-board! Please replace {Please write here} with your description -->

### What was the feature/problem?
Search fails when there isn't an assigned sponsor
Notes:
Although I haven't tried to save a wish without child name or child hometown, those values also might end up as null?

### How does this PR address the above feature/problem?

Before attempting to lowercase the value, check if it exists first. If it does not exist return empty string.

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed
- [x] Coding style (indentation, etc)

### Additional Comments (if any)

{Please write here}
