### PR TITLE
Add logout state; handle missing sponsor name

### DIFF
--- a/ui/src/app/App.js
+++ b/ui/src/app/App.js
@@ -17,6 +17,7 @@ function App() {
           <Route exact path="/landing" component={CreateWish} />
           <Route exact path="/wish-summary" component={WishList} />
           <Route exact path="/wish-summary/:id" component={WishDetails} />
+          <Route exact path="/logout" component={Login} />
           <Route exact path="/" component={Login} />
         </Switch>
       </WatchAuth>

--- a/ui/src/app/App.test.js
+++ b/ui/src/app/App.test.js
@@ -12,15 +12,23 @@ describe('Default routing behavior', () => {
   it('renders the login page by default', () => {
     const wrapper = shallow(<App />)
 
-    let loginRoute = wrapper
+    const loginRoute = wrapper
       .find(Route)
-      .at(4)
+      .at(5)
       .props()
 
     expect(loginRoute.path).toEqual('/')
     expect(loginRoute.component).toEqual(Login)
 
-    let wishDetailsRoute = wrapper
+    const logoutRoute = wrapper
+      .find(Route)
+      .at(4)
+      .props()
+
+    expect(logoutRoute.path).toEqual('/logout')
+    expect(logoutRoute.component).toEqual(Login)
+
+    const wishDetailsRoute = wrapper
       .find(Route)
       .at(3)
       .props()
@@ -28,7 +36,7 @@ describe('Default routing behavior', () => {
     expect(wishDetailsRoute.path).toEqual('/wish-summary/:id')
     expect(wishDetailsRoute.component).toEqual(WishDetails)
 
-    let wishCurationRoute = wrapper
+    const wishCurationRoute = wrapper
       .find(Route)
       .at(2)
       .props()
@@ -36,7 +44,7 @@ describe('Default routing behavior', () => {
     expect(wishCurationRoute.path).toEqual('/wish-summary')
     expect(wishCurationRoute.component).toEqual(WishList)
 
-    let landingRoute = wrapper
+    const landingRoute = wrapper
       .find(Route)
       .at(1)
       .props()
@@ -44,7 +52,7 @@ describe('Default routing behavior', () => {
     expect(landingRoute.path).toEqual('/landing')
     expect(landingRoute.component).toEqual(CreateWish)
 
-    let childInfoRoute = wrapper
+    const childInfoRoute = wrapper
       .find(Route)
       .at(0)
       .props()

--- a/ui/src/wishList/index.js
+++ b/ui/src/wishList/index.js
@@ -37,11 +37,12 @@ export default class WishList extends Component {
     })
   }
 
+
   filterWishes = (e) => {
     const wishFilter = e.target.value;
     let filteredWishes = this.state.wishes;
     filteredWishes = filteredWishes.filter((wish) => {
-      let wishItem = wish.child.name.toLowerCase() + wish.sponsor.name.toLowerCase() + wish.child.hometown.toLowerCase();
+      let wishItem = `${wish.child.name.toLowerCase()} ${wish.sponsor.name ? wish.sponsor.name.toLowerCase() : ''} ${wish.child.hometown.toLowerCase()}`;
       return wishItem.indexOf(
         wishFilter.toLowerCase()) !== -1
     })


### PR DESCRIPTION
<!-- Thank you for your contribution to the infinite-wish-board! Please replace {Please write here} with your description -->

### What was the feature/problem?

- "Logout" would take you to an empty page with no easy way to log back in.
- Missing `sponsor.name` would cause a run-time error ("TypeError: Cannot read property 'toLowerCase' of undefined)

### How does this PR address the above feature/problem?

- Reusing `Login` component for `/logout` path.
- Ensure `sponsor.name` exists before calling `toLowerCase`

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed
- [x] Coding style (indentation, etc)

### Other notes

- I noticed "Mary" is hard-coded next to the logout button? Is this intended? If not, maybe I can make a new PR.