### PR TITLE
For issue #79, handled search fails when there is not an assigned sponsor

### DIFF
--- a/ui/src/wishList/index.js
+++ b/ui/src/wishList/index.js
@@ -42,7 +42,11 @@ export default class WishList extends Component {
     const wishFilter = e.target.value;
     let filteredWishes = this.state.wishes;
     filteredWishes = filteredWishes.filter((wish) => {
-      let wishItem = `${wish.child.name.toLowerCase()} ${wish.sponsor.name ? wish.sponsor.name.toLowerCase() : ''} ${wish.child.hometown.toLowerCase()}`;
+      const childName = `${wish && wish.child && wish.child.name ? wish.child.name.toLowerCase() : ''}`;
+      const childHometown = `${wish && wish.child && wish.child.hometown ? wish.child.hometown.toLowerCase() : ''}`;
+      const sponsorName = `${wish && wish.sponsor && wish.sponsor.name ? wish.sponsor.name.toLowerCase() : ''}`;
+
+      const wishItem = `${childName} ${sponsorName} ${childHometown}`
       return wishItem.indexOf(
         wishFilter.toLowerCase()) !== -1
     })

--- a/ui/src/wishList/index.test.js
+++ b/ui/src/wishList/index.test.js
@@ -164,4 +164,34 @@ describe('WishSummary tests', () => {
       expect(wrapper.instance().state.filteredWishes).toEqual(mockWishList)
     })
   })
+
+  describe('when filterWishes func called by sponsor, but there is not an assigned sponsor', () => {
+    let wrapper
+    beforeEach(() => {
+      getWishes.mockImplementation(() => {
+        return [
+          {
+            _id: '1',
+            something: "wrong",
+          },
+          {
+            _id: '2',
+            something: "incorrect"
+          }
+        ]
+      })
+      wrapper = shallow(<WishSummary />)
+    })
+
+    it('should update filterWishes to be an empty array', async () => {
+      let clickEvt = {
+        target: {
+          value: 'Home Depot'
+        }
+      }
+
+      wrapper.instance().filterWishes(clickEvt)
+      expect(wrapper.instance().state.filteredWishes).toEqual([])
+    })
+  })
 })


### PR DESCRIPTION
<!-- Thank you for your contribution to the infinite-wish-board! Please replace {Please write here} with your description -->

### What was the feature/problem?
It is for open issue #79 
> **Summary:**
> Search fails when wish doesn't have a sponsor
> 
> **Steps to Reproduce:**
> Create a wish
> Skip adding a sponsor
> On the wish list page, search for a phrase
> Error displays: TypeError: undefined is not an object (evaluating 'wish.sponsor.name.toLowerCase')
> 
> Resolution: Check for null before trying to treat the value as a string
> src/wishList/index.js:44
> let wishItem = wish.child.name.toLowerCase() + wish.sponsor.name.toLowerCase() + wish.child.hometown.toLowerCase();
> 
> <img alt="WishBoard-Search-FailsWhenNoSponsor" width="1030" src="https://user-images.githubusercontent.com/48930585/66015383-50064800-e4a0-11e9-9df8-11b4927d386a.png">
> 
> **Notes:**
> Although I haven't tried to save a wish without child name or child hometown, those values also might end up as null?

### How does this PR address the above feature/problem?

Handled undefine and null conditions for sponsor name, child name, and child hometown from each wish object.

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed
- [x] Coding style (indentation, etc)

