### PR TITLE
Bugfix/filtering date

### DIFF
--- a/ui/src/wishList/index.js
+++ b/ui/src/wishList/index.js
@@ -45,15 +45,21 @@ export default class WishList extends Component {
       const childName = `${wish && wish.child && wish.child.name ? wish.child.name.toLowerCase() : ''}`;
       const childHometown = `${wish && wish.child && wish.child.hometown ? wish.child.hometown.toLowerCase() : ''}`;
       const sponsorName = `${wish && wish.sponsor && wish.sponsor.name ? wish.sponsor.name.toLowerCase() : ''}`;
-
-      const wishItem = `${childName} ${sponsorName} ${childHometown}`
+      let dateMonth = '';
+      let dateDay = '';
+      if (wish && wish.createdAt) {
+        const date = new Date(wish.createdAt);
+        dateMonth = date.toLocaleString('default', { month: 'long' }).toLowerCase();
+        dateDay = date.getDate();
+      }
+      const wishItem = `${childName} ${sponsorName} ${childHometown} ${dateMonth} ${dateDay}`;
       return wishItem.indexOf(
         wishFilter.toLowerCase()) !== -1
-    })
+    });
     this.setState({
       filteredWishes
     })
-  }
+  };
 
   render() {
     const { filteredWishes } = this.state

--- a/ui/src/wishList/index.test.js
+++ b/ui/src/wishList/index.test.js
@@ -61,8 +61,8 @@ describe('WishSummary tests', () => {
       _id: '5d070ba5db7b540028dea1c5',
       type: 'go',
       details: 'dfehjhgjhgjdf',
-      createdAt: '2019-06-17T03:40:21.782Z',
-      updatedAt: '2019-06-17T03:40:21.782Z',
+      createdAt: '2019-07-18T03:40:21.782Z',
+      updatedAt: '2019-07-18T03:40:21.782Z',
       __v: 0
     }
   ]
@@ -192,6 +192,25 @@ describe('WishSummary tests', () => {
 
       wrapper.instance().filterWishes(clickEvt)
       expect(wrapper.instance().state.filteredWishes).toEqual([])
+    })
+  })
+
+  describe('when filterWishes func called by date month', () => {
+    let wrapper
+    beforeEach(() => {
+      getWishes.mockImplementation(() => mockWishList)
+      wrapper = shallow(<WishSummary />)
+    })
+
+    it('should update filterWishes by date month', async () => {
+      let clickEvt = {
+        target: {
+          value: 'july'
+        }
+      }
+
+      wrapper.instance().filterWishes(clickEvt)
+      expect(wrapper.instance().state.filteredWishes).toEqual([mockWishList[2]])
     })
   })
 })


### PR DESCRIPTION
### What was the feature/problem?

Filtering by date is not working

### How does this PR address the above feature/problem?

Allows filtering by wish's month and/or numeric date

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed
- [x] Coding style (indentation, etc)
