### PR TITLE
Auto launch wish

### DIFF
--- a/ui/src/childinfo/ChildInfo.js
+++ b/ui/src/childinfo/ChildInfo.js
@@ -182,13 +182,6 @@ export default class ChildInfo extends Component {
               src={rocketImage}
               alt={rocketImage}
             />
-            <button
-              className="rocket-blast-off-button"
-              onClick={this.rocketBlastOff}
-              disabled={this.state.launchRocket}
-            >
-              Fulfill my wish
-            </button>
           </div>
         )}
       </>

--- a/ui/src/childinfo/ChildInfo.js
+++ b/ui/src/childinfo/ChildInfo.js
@@ -94,6 +94,8 @@ export default class ChildInfo extends Component {
 
       const response = await WishDetailsService.makeAWish(wish)
 
+      this.rocketBlastOff();
+
       this.setState({
         showConfirmation: true,
         childId: response._id

--- a/ui/src/childinfo/ChildInfo.js
+++ b/ui/src/childinfo/ChildInfo.js
@@ -94,12 +94,12 @@ export default class ChildInfo extends Component {
 
       const response = await WishDetailsService.makeAWish(wish)
 
-      this.rocketBlastOff();
-
       this.setState({
         showConfirmation: true,
         childId: response._id
       })
+
+      this.rocketBlastOff();
     }
   }
 

--- a/ui/src/childinfo/ChildInfo.test.js
+++ b/ui/src/childinfo/ChildInfo.test.js
@@ -136,17 +136,13 @@ describe('Initial Render', () => {
     })
   })
 
-  describe('When user on confirmation page, blast off the rocket', () => {
+  describe('When user on confirmation page after third Next button click, blast off the rocket', () => {
     const play = jest.fn()
     const pause = jest.fn()
     const push = jest.fn()
 
     beforeEach(() => {
       childInfo = shallow(<ChildInfo name={testName} age={age} />);
-      childInfo.instance().setState({
-        showConfirmation: true,
-        isBlastOff: false
-      })
 
       childInfo.instance().soundEffect = {
         play,
@@ -166,8 +162,11 @@ describe('Initial Render', () => {
       push.mockClear()
     })
 
-    it('Should play and pause sound effect, and push to next url', (done) => {      
-      childInfo.find('.rocket-blast-off-button').simulate('click')
+    it('Should play and pause sound effect, and push to next url', async (done) => {      
+      let nextButton = childInfo.find('.next-button');
+      await nextButton.simulate('click');
+      await nextButton.simulate('click');
+      await nextButton.simulate('click');
       setTimeout(() => {
         expect(play.mock.calls.length).toEqual(1)
         expect(pause.mock.calls.length).toEqual(1)

--- a/ui/src/childinfo/ChildInfo.test.js
+++ b/ui/src/childinfo/ChildInfo.test.js
@@ -136,7 +136,7 @@ describe('Initial Render', () => {
     })
   })
 
-  describe('When user on confirmation page and click blast off the rocket', () => {
+  describe('When user on confirmation page, blast off the rocket', () => {
     const play = jest.fn()
     const pause = jest.fn()
     const push = jest.fn()


### PR DESCRIPTION
### What was the feature/problem?

We have changed the desired wisher workflow to automatically launch the rocket after saving the wish

### How does this PR address the above feature/problem?

Removed the Fulfill my wish button
Triggers rocket launch after saving wish

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed
- [x] Coding style (indentation, etc)

### Additional Comments (if any)

